### PR TITLE
Added authorization type/scheme (default BASIC)

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -280,7 +280,11 @@ void HTTPClient::setAuthorization(const char * user, const char * password)
         _base64Authorization = base64::encode(auth);
     }
 }
-
+void HTTPClient::setAuthorizationType(const char * type) {
+	if (type) {
+		_autorizationType = type;
+	}
+}
 /**
  * set the Authorizatio for the http request
  * @param auth const char * base64
@@ -335,20 +339,6 @@ int HTTPClient::POST(uint8_t * payload, size_t size)
 
 int HTTPClient::POST(String payload)
 {
-    return POST((uint8_t *) payload.c_str(), payload.length());
-}
-
-/**
- * sends a put request to the server
- * @param payload uint8_t *
- * @param size size_t
- * @return http code
- */
-int HTTPClient::PUT(uint8_t * payload, size_t size) {
-    return sendRequest("PUT", payload, size);
-}
-
-int HTTPClient::PUT(String payload) {
     return POST((uint8_t *) payload.c_str(), payload.length());
 }
 
@@ -888,7 +878,9 @@ bool HTTPClient::sendHeader(const char * type)
 
     if(_base64Authorization.length()) {
         _base64Authorization.replace("\n", "");
-        header += F("Authorization: Basic ");
+        header += F("Authorization: ");
+        header += _autorizationType;
+        header += ' ';
         header += _base64Authorization;
         header += "\r\n";
     }

--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.h
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.h
@@ -148,6 +148,7 @@ public:
     void setUserAgent(const String& userAgent);
     void setAuthorization(const char * user, const char * password);
     void setAuthorization(const char * auth);
+    void setAuthorizationType(const char * type);
     void setTimeout(uint16_t timeout);
 
     void useHTTP10(bool usehttp10 = true);
@@ -156,8 +157,6 @@ public:
     int GET();
     int POST(uint8_t * payload, size_t size);
     int POST(String payload);
-    int PUT(uint8_t * payload, size_t size);
-    int PUT(String payload);
     int sendRequest(const char * type, String payload);
     int sendRequest(const char * type, uint8_t * payload = NULL, size_t size = 0);
     int sendRequest(const char * type, Stream * stream, size_t size = 0);
@@ -212,6 +211,7 @@ protected:
     String _headers;
     String _userAgent = "ESP8266HTTPClient";
     String _base64Authorization;
+    String _autorizationType = "Basic";
 
     /// Response handling
     RequestArgument* _currentHeaders = nullptr;


### PR DESCRIPTION
ESP8266HttpClient uses fixed authorization scheme (BASIC). Add the possibility to use other schemes such as Bearer or Digest with setAutorizationType(String);